### PR TITLE
chore: include contracts and frontend in root test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   "homepage": "https://github.com/kawacukennedy/kuberna-labs#readme",
   "scripts": {
     "compile": "hardhat compile",
-    "test": "npm run test:backend && npm run test:sdk",
+    "test": "npm run test:backend && npm run test:sdk && npm run test:contracts && npm run test:frontend",
     "test:backend": "cd backend && npm test",
     "test:sdk": "cd sdk && npm test",
     "test:contracts": "hardhat test",
+    "test:frontend": "cd frontend && npm test",
     "deploy:local": "hardhat run scripts/deploy.ts --network localhost",
     "deploy:sepolia": "hardhat run scripts/deploy.ts --network sepolia",
     "verify": "hardhat run scripts/verify.ts",


### PR DESCRIPTION
## Summary

- update the root `npm test` script so it runs backend, SDK, contract, and frontend test suites
- add a root `test:frontend` script that delegates to the existing frontend test command

Closes #19.

## Verification

- `npm ci --legacy-peer-deps`
- `npm run test:contracts`
- `npm run test:frontend -- --runInBand`
- `npm test -- --runInBand`
- `git diff --check`

Notes:

- I kept the frontend runner on the repository's existing Jest setup instead of introducing a Vitest migration in this small PR.
- `npm ci` reports existing audit findings, and backend Jest reports an existing worker teardown warning while all test suites pass.
