### PR TITLE
chore(ci): restore main lint checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,7 @@ git checkout -b fix/my-bugfix
 ```
 
 Branch naming:
+
 - `feat/` — new features
 - `fix/` — bug fixes
 - `docs/` — documentation only
@@ -400,14 +401,14 @@ test: add unit tests for VirtualsManager
 
 ### Areas to Contribute
 
-| Area | Description | Location |
-|---|---|---|
-| **SDK** | TypeScript client library | `sdk/` |
-| **Smart Contracts** | Solidity contracts (Escrow, Dispute, Router, etc.) | `contracts/` |
-| **Backend** | Node.js API server | `backend/` |
-| **Frontend** | Next.js dashboard | (root `pages/`, `components/`) |
-| **Documentation** | README, guides, JSDoc, NatSpec | `.md` files, inline docs |
-| **DevOps** | CI/CD, Docker, Render config | `.github/`, `render.yaml`, `Dockerfile` |
+| Area                | Description                                        | Location                                |
+| ------------------- | -------------------------------------------------- | --------------------------------------- |
+| **SDK**             | TypeScript client library                          | `sdk/`                                  |
+| **Smart Contracts** | Solidity contracts (Escrow, Dispute, Router, etc.) | `contracts/`                            |
+| **Backend**         | Node.js API server                                 | `backend/`                              |
+| **Frontend**        | Next.js dashboard                                  | (root `pages/`, `components/`)          |
+| **Documentation**   | README, guides, JSDoc, NatSpec                     | `.md` files, inline docs                |
+| **DevOps**          | CI/CD, Docker, Render config                       | `.github/`, `render.yaml`, `Dockerfile` |
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -263,17 +263,17 @@ Optional: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `REDIS_URL`, `SMTP_*` fo
 
 ### Sponsor Integrations
 
-| Sponsor | Status | What It Powers |
-|---------|--------|----------------|
-| **Virtuals** | ✅ Live | LLM backend (Claude Opus 4 via ACP) |
-| **Pyth Network** | ✅ Live | Price oracle (ETH, BTC, USDC) |
-| **Discord** | ✅ Live | CI notifications + GitHub star alerts |
-| **Stripe** | 🔧 Code ready | Fiat payments + subscriptions (needs API key) |
-| **Kite AI** | 🔧 Code ready | Agent payments (x402 protocol) |
-| **SilentVerify** | 🔧 Code ready | Post-quantum agent PKI |
-| **Infura / Alchemy** | ✅ Local | RPC providers for contract deployment |
+| Sponsor              | Status        | What It Powers                                |
+| -------------------- | ------------- | --------------------------------------------- |
+| **Virtuals**         | ✅ Live       | LLM backend (Claude Opus 4 via ACP)           |
+| **Pyth Network**     | ✅ Live       | Price oracle (ETH, BTC, USDC)                 |
+| **Discord**          | ✅ Live       | CI notifications + GitHub star alerts         |
+| **Stripe**           | 🔧 Code ready | Fiat payments + subscriptions (needs API key) |
+| **Kite AI**          | 🔧 Code ready | Agent payments (x402 protocol)                |
+| **SilentVerify**     | 🔧 Code ready | Post-quantum agent PKI                        |
+| **Infura / Alchemy** | ✅ Local      | RPC providers for contract deployment         |
 
-*See [docs/FUNDING-REPORT.md](./docs/FUNDING-REPORT.md) for a full list of 78+ funding opportunities across 7 categories.*
+_See [docs/FUNDING-REPORT.md](./docs/FUNDING-REPORT.md) for a full list of 78+ funding opportunities across 7 categories._
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---|---|
-| >= 1.0.x | ✅ |
+| Version  | Supported |
+| -------- | --------- |
+| >= 1.0.x | ✅        |
 
 ## Reporting a Vulnerability
 

--- a/scripts/cross-chain-analysis.ts
+++ b/scripts/cross-chain-analysis.ts
@@ -1,9 +1,9 @@
-import { config } from "dotenv";
+import { config } from 'dotenv';
 config({ path: `${__dirname}/../.env` });
 
-const API_KEY = process.env.AI_API_KEY || "";
-const BASE_URL = process.env.AI_BASE_URL || "https://compute.virtuals.io/v1";
-const MODEL = process.env.AI_MODEL || "anthropic-claude-opus-4-7";
+const API_KEY = process.env.AI_API_KEY || '';
+const BASE_URL = process.env.AI_BASE_URL || 'https://compute.virtuals.io/v1';
+const MODEL = process.env.AI_MODEL || 'anthropic-claude-opus-4-7';
 const VIRTUAL_API_KEY = process.env.VIRTUAL_API_KEY || API_KEY;
 
 interface ChainAnalysis {
@@ -30,16 +30,16 @@ async function callVirtuals(
   maxTokens = 2000
 ): Promise<{ content: string; cost: number }> {
   const response = await fetch(`${BASE_URL}/chat/completions`, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
+      'Content-Type': 'application/json',
       Authorization: `Bearer ${API_KEY}`,
     },
     body: JSON.stringify({
       model: MODEL,
       messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt },
       ],
       temperature: 0.3,
       max_tokens: maxTokens,
@@ -56,7 +56,7 @@ async function callVirtuals(
     cost?: { usd?: number };
   };
 
-  const content = data.choices?.[0]?.message?.content || "";
+  const content = data.choices?.[0]?.message?.content || '';
   const cost = data.cost?.usd || 0;
 
   return { content, cost };
@@ -103,12 +103,12 @@ Include 4-6 chains and 2-3 best opportunities.`;
 
   let report: CrossChainReport;
   try {
-    const cleaned = content.replace(/```json|```/g, "").trim();
+    const cleaned = content.replace(/```json|```/g, '').trim();
     report = JSON.parse(cleaned);
   } catch {
     report = {
       timestamp: new Date().toISOString(),
-      marketOverview: "Failed to parse structured analysis",
+      marketOverview: 'Failed to parse structured analysis',
       chains: [],
       bestOpportunities: [],
       agentRecommendation: content.substring(0, 500),
@@ -133,7 +133,7 @@ if (require.main === module) {
       console.log(`Model: ${MODEL}`);
     })
     .catch((err) => {
-      console.error("Analysis failed:", err);
+      console.error('Analysis failed:', err);
       process.exit(1);
     });
 }

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -12,8 +12,6 @@ import { AiManager } from './ai.js';
 import { CrossChainIdentityManager } from './identity/crossChainIdentity.js';
 import { SilentVerifyManager } from './silentverify.js';
 import { KiteManager } from './kite.js';
-import { DubstrataManager } from './dubstrata.js';
-import { VirtualsManager } from './virtuals.js';
 
 export interface KubernaConfig {
   apiKey?: string;


### PR DESCRIPTION
## Summary

Restores the lint path that is currently failing on `main`.

- remove two unused SDK imports reported by ESLint
- apply the repository's Prettier configuration to the four files reported by `format:check`

Failed run: https://github.com/kawacukennedy/kuberna-labs/actions/runs/29359950464

## Verification

- `npm run lint` (0 errors; existing warnings remain)
- `npm run format:check`
- `npx solhint 'contracts/**/*.sol'`
- `npm test` (175 backend, 15 SDK, 215 contract, 7 frontend tests)
- Hardhat compile and backend, SDK, and frontend production builds
- `git diff --check`
