### PR TITLE
test(sdk): cover JCS canonicalization edge cases

### DIFF
--- a/sdk/test/verify.test.ts
+++ b/sdk/test/verify.test.ts
@@ -1,0 +1,35 @@
+import { jcsCanonicalize } from '../src/verify/jcs.js';
+
+describe('jcsCanonicalize', () => {
+  it('serializes BigInt values as decimal integers', () => {
+    expect(jcsCanonicalize(9007199254740993n)).toBe('9007199254740993');
+  });
+
+  it('encodes Unicode code points above U+FFFF as surrogate pairs', () => {
+    expect(jcsCanonicalize('\u{1f600}')).toBe('"\\ud83d\\ude00"');
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+  ])('canonicalizes %s as null', (_label, value) => {
+    expect(jcsCanonicalize(value)).toBe('null');
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['-Infinity', Number.NEGATIVE_INFINITY],
+  ])('rejects %s', (_label, value) => {
+    expect(() => jcsCanonicalize(value)).toThrow('JCS does not support Infinity or NaN');
+  });
+
+  it('canonicalizes empty objects and arrays', () => {
+    expect(jcsCanonicalize({})).toBe('{}');
+    expect(jcsCanonicalize([])).toBe('[]');
+  });
+
+  it('escapes control characters', () => {
+    expect(jcsCanonicalize('\b\t\n\f\r\u0000')).toBe('"\\b\\t\\n\\f\\r\\u0000"');
+  });
+});


### PR DESCRIPTION
## Description

Adds direct Jest coverage for the JCS edge cases listed in #34:

- BigInt serialization
- Unicode surrogate pairs
- `null` and `undefined`
- `NaN` and positive/negative Infinity
- empty objects and arrays
- control-character escaping

This is test-only and does not change runtime behavior.

Closes #34

## Testing

- `npm test` (421 tests passed)
- `npm run lint` (0 errors)
- `npm run format:check`
- SDK, backend, and frontend builds
- frontend lint and TypeScript check
