### PR TITLE
fix(ci): restore checks after agent pipeline update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # Session Summary
 
 ## Goal
+
 Complete Kuberna Labs deployment across target chains, submit to BNB hackathons, and actively contribute to OM World Protocol as a Genesis Co-author to deepen the partnership.
 
 ## Constraints & Preferences
+
 - Use Foundry for Solidity, Hardhat for verification
 - TypeScript/Node SDK
 - Prefer deterministic deployment (CREATE2 via Safe Singleton Factory)
@@ -12,6 +14,7 @@ Complete Kuberna Labs deployment across target chains, submit to BNB hackathons,
 ## Progress
 
 ### Done
+
 - Three Foundry deploy scripts for MLRWA tokens, Governance, Registry
 - Deterministic address computation with CREATE2 (Safe Singleton Factory) — all deployments
 - Codebase analysis: project structure, configs, and dependency mapping complete
@@ -24,6 +27,7 @@ Complete Kuberna Labs deployment across target chains, submit to BNB hackathons,
 - Cross-chain analysis pipeline
 
 ### AI Agent Pipeline (NEW — Jul 15-16)
+
 - **5 production agents created and running** (Dubstrata Trader, yield-trader, defi-trader, arbitrage-trader, Trading Bot template)
 - **Agent pipeline 6/6 steps working**: resolve → LLM intent parse → market analysis → agent decision → intent creation → trace logging
 - **Real market data**: Pyth oracle ETH $1,914, BTC $64,673, DEX spreads, APY rates (Marinade 6.5%, Curve 5.2%)
@@ -34,11 +38,13 @@ Complete Kuberna Labs deployment across target chains, submit to BNB hackathons,
 - **SDK v1.0.5 published**: `VIRTUALS_API_KEY` env var support added
 
 ### Sponsorship Status
+
 - **Virtuals ($200/wk)**: Free inference credits active (Tier 1: Spark, week 2/4). ACP key `acp-cd4a8b03071a3903b8e7` authenticates but needs auto-billing authorized to access compute credits. Models listed: 52 available.
 - **Dubstrata ($100)**: API working, $99.79 remaining. Queries return real ETF/crypto price data, volatility, sentiment scores. Integrated into agent pipeline.
 - **Dubstrata fixes**: SDK base URL corrected to `api.dubstrata.com`, `/query` endpoint confirmed working, intelligence report needs `/query/intelligence-report` path.
 
 ### GitHub Growth
+
 - Release v1.0.4 created, Discussions + Projects enabled
 - 7 good-first-issue tickets (#30-#36), 1 help-wanted (#37)
 - CONTRIBUTORS.md, SECURITY.md, FUNDING.yml updated
@@ -46,6 +52,7 @@ Complete Kuberna Labs deployment across target chains, submit to BNB hackathons,
 - ElizaOS #9810: Authority fixture corrected per @0xddneto review
 
 ### Blocked
+
 - Sepolia: faucet empty
 - Polygon Amoy: RPC issues, no ETH
 - Arbitrum Sepolia: no ETH
@@ -55,40 +62,47 @@ Complete Kuberna Labs deployment across target chains, submit to BNB hackathons,
 - Dubstrata $100 provisioned but some endpoints returning 404 (`/intelligence-report`)
 
 ## Key Decisions
+
 - OM World: execute unfulfilled commitments first
 - Tool Registry: tool-defined defaults with per-deployment overrides
 - Execution Proof: Kuberna Router as reference implementation
 
 ## Repos & Accounts
+
 - User: `kawacukennedy` (GitHub)
 - OM World org: `omworldprotocol`
 - Kuberna SDK: this repo
 
 ## Deployer Wallet
+
 - Address: `0x90b3...7d60`
 - PK: `0xac00...0100`
 - Safe Singleton Factory: `0x4e59b44847b379578588920cA78FbF26c0B4956C`
 
 ## SimpleAccount (Base Sepolia)
+
 - Account: `0x7a3175bC23f4be167e49132A22d8e68B3a128aB1`
 - Owner: `0x90b37Cf2A756D0DcD2F69A2De78e5CA443eD7d60`
 - Block: 43938074
 
 ## Deployed Addresses (all deterministic via CREATE2)
+
 - MLRWA Token (Eth Sepolia): `0x4d06b1d10f41cf68cd7cd7b9c5be9d7b92c7a62b`
 - MLRWA Token (Base Sepolia): `0x4d06b1d10f41cf68cd7cd7b9c5be9d7b92c7a62b`
 - Governance (Base Sepolia): `0x4d059e5bfc5a5f6d19e0d32d6157ef0d16b7aedb`
 - Registry (Base Sepolia): `0x4d059e5bfc5a5f6d19e0d32d6157ef0d16b7aedb`
 
 ## Production Agents (Base Sepolia)
-| Name | ID | Status |
-|------|-----|--------|
+
+| Name             | ID            | Status  |
+| ---------------- | ------------- | ------- |
 | Dubstrata Trader | `4da8e520...` | RUNNING |
-| yield-trader | `4e4aacfd...` | RUNNING |
-| defi-trader | `8163641d...` | RUNNING |
+| yield-trader     | `4e4aacfd...` | RUNNING |
+| defi-trader      | `8163641d...` | RUNNING |
 | arbitrage-trader | `18309ace...` | RUNNING |
 
 ## Common Commands
+
 ```bash
 # Deploy contracts
 forge script script/DeployMLRWAToken.s.sol --rpc-url $RPC_URL --broadcast --verify -vvvv
@@ -112,6 +126,7 @@ curl -s https://compute.virtuals.io/v1/chat/completions \
 ```
 
 ## Next Steps
+
 1. **Authorize Virtuals auto-billing** in console (preferred chain: 8453 Base) to unlock $200/wk compute
 2. Publish ERC-8004 adapter as npm release
 3. Monitor v0.2 freeze from @flyoung588

--- a/backend/test/agentLifecycle.test.ts
+++ b/backend/test/agentLifecycle.test.ts
@@ -77,7 +77,13 @@ jest.mock('../src/services/index', () => ({
 
 jest.mock('../src/utils/logger', () => ({
   __esModule: true,
-  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), child: jest.fn() },
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  },
 }));
 
 jest.mock('../src/services/priceFeed', () => ({

--- a/scripts/agent-deep-test.ts
+++ b/scripts/agent-deep-test.ts
@@ -54,7 +54,7 @@ async function testDubstrata() {
       const claims = result.structured_result?.claims || [];
       console.log(
         `  [${result.status}] $${result.remaining_balance.toFixed(3)} | ` +
-        `${pa.length} prices, ${claims.length} claims | Cost: $${(result.execution_cost || 0).toFixed(4)}`
+          `${pa.length} prices, ${claims.length} claims | Cost: $${(result.execution_cost || 0).toFixed(4)}`
       );
     } catch (err) {
       console.log(`  ❌ Query failed: ${err instanceof Error ? err.message : 'unknown error'}`);
@@ -94,8 +94,8 @@ async function testAgentPipeline() {
 
       console.log(
         `  [${result.success ? '✅' : '❌'}] "${task.slice(0, 40)}" | ` +
-        `${failed.length}/${steps.length} failed | ` +
-        `Decision: ${action.type}`
+          `${failed.length}/${steps.length} failed | ` +
+          `Decision: ${action.type}`
       );
     } catch (err) {
       console.log(`  ❌ Run failed: ${err instanceof Error ? err.message : 'unknown error'}`);


### PR DESCRIPTION
## Summary

- add the missing `debug` method to the logger mock in `agentLifecycle.test.ts`
- run Prettier on the two files reported by the current `main` CI run

## Why

Current `main@12ed8267` fails the backend and Prettier checks. The adjacent
`agentDecision` logger mock was updated in `632bafc`, but the lifecycle test
still uses the older mock shape. This applies the same logger contract there
and formats only the files named by CI.

I kept this separate from #39 so the JCS test PR remains scoped to issue #34.

## Verification

- `npm test` - 175 backend, 15 SDK, 215 contract, and 7 frontend tests pass
- `npm run lint` - 0 errors; existing warnings only
- `npm run format:check`
- backend, SDK, and frontend production builds
- `git diff --check`
