### PR TITLE
test: add TeeManager, CertificateManager, AiManager tests (supersedes #60)

### DIFF
--- a/sdk/test/ai.test.ts
+++ b/sdk/test/ai.test.ts
@@ -1,0 +1,81 @@
+import { AiManager } from '../src/ai.js';
+
+describe('AiManager', () => {
+  let mockSDK: any;
+  let aiManager: AiManager;
+
+  beforeEach(() => {
+    mockSDK = {
+      request: jest.fn(),
+    };
+
+    aiManager = new AiManager(mockSDK);
+  });
+
+  describe('parseIntent', () => {
+    it('parses intent from description', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          sourceChain: 'ethereum',
+          sourceToken: 'USDC',
+          sourceAmount: '100',
+          destChain: 'polygon',
+          destToken: 'USDC',
+          minDestAmount: '99',
+          timeoutSeconds: 3600,
+          budget: 10,
+          currency: 'USDC',
+          confidence: 0.95,
+          rawDescription: 'Transfer 100 USDC from Ethereum to Polygon',
+        },
+      });
+
+      const result = await aiManager.parseIntent('Transfer 100 USDC from Ethereum to Polygon');
+
+      expect(result.sourceChain).toBe('ethereum');
+      expect(result.destChain).toBe('polygon');
+      expect(result.sourceToken).toBe('USDC');
+      expect(result.confidence).toBe(0.95);
+    });
+  });
+
+  describe('getDecision', () => {
+    it('returns agent decision', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          action: 'swap',
+          reason: 'Best rate found',
+          confidence: 0.9,
+          parameters: { protocol: 'uniswap' },
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await aiManager.getDecision('agent-1', { market: 'bullish' });
+
+      expect(result.action).toBe('swap');
+      expect(result.confidence).toBe(0.9);
+    });
+  });
+
+  describe('analyze', () => {
+    it('analyzes text and returns result', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          intent: 'market_analysis',
+          entities: { token: 'ETH', price: '3000' },
+          sentiment: 'positive',
+          confidence: 0.85,
+        },
+      });
+
+      const result = await aiManager.analyze({
+        text: 'ETH price is going up',
+      });
+
+      expect(result.intent).toBe('market_analysis');
+      expect(result.sentiment).toBe('positive');
+      expect(result.confidence).toBe(0.85);
+    });
+  });
+});

--- a/sdk/test/certificate.test.ts
+++ b/sdk/test/certificate.test.ts
@@ -1,0 +1,86 @@
+import { CertificateManager } from '../src/certificate.js';
+
+describe('CertificateManager', () => {
+  let mockSDK: any;
+  let certificateManager: CertificateManager;
+
+  beforeEach(() => {
+    mockSDK = {
+      request: jest.fn(),
+    };
+
+    certificateManager = new CertificateManager(mockSDK);
+  });
+
+  describe('mint', () => {
+    it('mints a certificate and returns it', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          id: 'cert-123',
+          tokenId: '1',
+          recipient: '0xRecipient0000000000000000000000000000',
+          courseId: 'course-1',
+          verificationHash: '0xabc',
+          chain: 'ethereum',
+          transactionHash: '0xtx',
+          mintedAt: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await certificateManager.mint({
+        recipientAddress: '0xRecipient0000000000000000000000000000',
+        courseId: 'course-1',
+      });
+
+      expect(result.id).toBe('cert-123');
+      expect(result.tokenId).toBe('1');
+      expect(result.recipient).toBe('0xRecipient0000000000000000000000000000');
+    });
+  });
+
+  describe('verify', () => {
+    it('verifies a certificate', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          valid: true,
+          certificate: { id: 'cert-123' },
+          issuer: '0xIssuer0000000000000000000000000000000',
+          timestamp: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await certificateManager.verify('cert-123');
+      expect(result.valid).toBe(true);
+      expect(result.issuer).toBe('0xIssuer0000000000000000000000000000000');
+    });
+  });
+
+  describe('getByUser', () => {
+    it('returns certificates for a user', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          certificates: [
+            { id: 'cert-1', tokenId: '1' },
+            { id: 'cert-2', tokenId: '2' },
+          ],
+        },
+      });
+
+      const result = await certificateManager.getByUser('user-1');
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('getByCourse', () => {
+    it('returns certificates for a course', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          certificates: [{ id: 'cert-1', tokenId: '1' }],
+        },
+      });
+
+      const result = await certificateManager.getByCourse('course-1');
+      expect(result).toHaveLength(1);
+    });
+  });
+});

--- a/sdk/test/tee.test.ts
+++ b/sdk/test/tee.test.ts
@@ -1,0 +1,93 @@
+import { TeeManager } from '../src/tee.js';
+
+describe('TeeManager', () => {
+  let mockSDK: any;
+  let teeManager: TeeManager;
+
+  beforeEach(() => {
+    mockSDK = {
+      request: jest.fn(),
+    };
+
+    teeManager = new TeeManager(mockSDK);
+  });
+
+  describe('createEnclave', () => {
+    it('creates an enclave and returns it', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          id: 'enclave-123',
+          name: 'test-enclave',
+          status: 'creating',
+          image: 'ubuntu:latest',
+          memory: 512,
+          cpu: 1,
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await teeManager.createEnclave({
+        name: 'test-enclave',
+        image: 'ubuntu:latest',
+      });
+
+      expect(result.id).toBe('enclave-123');
+      expect(result.status).toBe('creating');
+    });
+  });
+
+  describe('getEnclave', () => {
+    it('returns enclave by id', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: { id: 'enclave-123', name: 'test', status: 'running' },
+      });
+
+      const result = await teeManager.getEnclave('enclave-123');
+      expect(result.id).toBe('enclave-123');
+    });
+  });
+
+  describe('listEnclaves', () => {
+    it('returns list of enclaves', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          enclaves: [{ id: '1', name: 'a' }, { id: '2', name: 'b' }],
+        },
+      });
+
+      const result = await teeManager.listEnclaves();
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('verifyAttestation', () => {
+    it('returns attestation report', async () => {
+      mockSDK.request.mockResolvedValue({
+        data: {
+          enclaveId: 'enclave-123',
+          report: 'report-data',
+          verified: true,
+          timestamp: '2024-01-01T00:00:00Z',
+          measurements: {
+            mrEnclave: 'abc',
+            mrSigner: 'def',
+            isvProdID: '1',
+            isvSVN: '2',
+          },
+        },
+      });
+
+      const result = await teeManager.verifyAttestation('enclave-123');
+      expect(result.verified).toBe(true);
+      expect(result.enclaveId).toBe('enclave-123');
+    });
+  });
+
+  describe('destroyEnclave', () => {
+    it('destroys enclave successfully', async () => {
+      mockSDK.request.mockResolvedValue({ data: {} });
+
+      await expect(teeManager.destroyEnclave('enclave-123')).resolves.not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Supersedes #60 — fixes the nested file paths from Mohammed's PR.

Adds unit tests for:
- TeeManager: createEnclave, getEnclave, listEnclaves, verifyAttestation, destroyEnclave
- CertificateManager: mint, verify, getByUser, getByCourse
- AiManager: parseIntent, getDecision, analyze

All files correctly placed at:
- sdk/test/tee.test.ts
- sdk/test/certificate.test.ts
- sdk/test/ai.test.ts

Closes #32