### PR TITLE
fix(security): redact sensitive fields from GET /api/users/:id

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -69,7 +69,20 @@ router.get(
 
       const user = await prisma.user.findUnique({
         where: { id },
-        include: {
+        select: {
+          id: true,
+          email: true,
+          fullName: true,
+          avatarUrl: true,
+          web3Address: true,
+          roles: true,
+          mfaEnabled: true,
+          authMethod: true,
+          emailVerified: true,
+          lastLogin: true,
+          loginCount: true,
+          createdAt: true,
+          updatedAt: true,
           profile: true,
           agents: {
             select: {


### PR DESCRIPTION
## Security Fix

**Severity:** High (CVSS 8.1) — CWE-639, CWE-200
**Endpoint:** GET /api/users/:id
**Reported by:** Security researcher (via email)

### Problem
The route used `prisma.user.findUnique` with `include` but no `select`, returning the full User model to any authenticated user. This leaked:
- `passwordHash` — offline brute-force
- `resetPasswordToken` + `resetPasswordExpires` — password reset account takeover
- `mfaSecret` — MFA bypass
- `emailVerificationToken` — email takeover

### Fix
Replaced `include` with explicit `select` that only returns safe fields (id, email, fullName, avatarUrl, roles, etc.).

### Verification
- [x] No other routes return raw User model (auth routes use explicit field selection)
- [x] Analytics route only selects `createdAt`
- [x] PATCH/DELETE routes already require ADMIN role
- [x] Local typecheck passes

### Impact
Zero functional change — all legitimate consumers of this endpoint already use the returned fields.