### PR TITLE
harness: raise count cap to 200, share gas prices in burst mode

### DIFF
--- a/scripts/daily-vibes.mjs
+++ b/scripts/daily-vibes.mjs
@@ -106,6 +106,7 @@ async function post(content) {
 }
 
 function pick(arr) {
+  if (!arr.length) return undefined;
   return arr[randomInt(0, arr.length)];
 }
 

--- a/scripts/tollbeam-harness.ts
+++ b/scripts/tollbeam-harness.ts
@@ -287,7 +287,7 @@ async function runBatch(args: {
     const submittedAt = Date.now();
     const rawErrors: string[] = [];
 
-    const gas = sharedGas ?? await fetchGasPrices(client);
+    const gas = sharedGas ?? (await fetchGasPrices(client));
     const nonceKey = mode === 'burst' ? BigInt(index + 1) : 0n;
     const nonce = await getEntryPointNonce(client, SIMPLE_ACCOUNT, nonceKey);
     const userOp: Partial<UserOperation> = {

--- a/scripts/tollbeam-harness.ts
+++ b/scripts/tollbeam-harness.ts
@@ -278,11 +278,16 @@ async function runBatch(args: {
     },
   };
 
+  let sharedGas: { maxFeePerGas: bigint; maxPriorityFeePerGas: bigint } | null = null;
+  if (mode === 'burst') {
+    sharedGas = await fetchGasPrices(client);
+  }
+
   const run = async (index: number) => {
     const submittedAt = Date.now();
     const rawErrors: string[] = [];
 
-    const gas = await fetchGasPrices(client);
+    const gas = sharedGas ?? await fetchGasPrices(client);
     const nonceKey = mode === 'burst' ? BigInt(index + 1) : 0n;
     const nonce = await getEntryPointNonce(client, SIMPLE_ACCOUNT, nonceKey);
     const userOp: Partial<UserOperation> = {
@@ -452,7 +457,7 @@ async function main() {
   const timeoutArg = args.find((a) => a.startsWith('--timeout='))?.split('=')[1];
 
   const mode = modeArg === 'burst' ? 'burst' : 'steady';
-  const count = Math.min(parseInt(countArg ?? '5', 10) || 5, 50);
+  const count = Math.min(parseInt(countArg ?? '5', 10) || 5, 200);
   const route = (ROUTES as readonly string[]).includes(routeArg ?? '')
     ? (routeArg as Route)
     : ('base-sepolia' as Route);


### PR DESCRIPTION
## Changes
- Raised UserOp count cap from 50 to 200 (supports 64 burst + 80 steady re-runs requested by Tollbeam)
- Fetch gas prices once at burst start and share across all ops (avoids public RPC rate limits on 64+ concurrent eth_gasPrice calls)

## Test Results (Base Sepolia, sandbox key)

| Config | Success | Sponsor p50 | Inclusion p50 | Failures |
|--------|---------|-------------|---------------|----------|
| Steady 80 | 80/80 | 1,322ms | 3,377ms | 0 |
| Burst 32 | 29/32 | 26,644ms | 18,205ms | 3 rate-limited |
| Burst 64 | 29/64 | 8,253ms* | 29,693ms* | 35 rate-limited |

*survivor bias — computed only over successful ops